### PR TITLE
Improves documentation and fixes small bug

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -24,7 +24,7 @@ class ExternalModule extends AbstractExternalModule {
 
             // Getting system settings
             $url = $this->getSystemSetting('mobile-api-request-to-survey-url');
-            $text = $this->getSystemSetting('mobile-api-request-to-survey-text');
+            $text = $this->getSystemSetting('mobile-api-request-to-survey-text') ?: '';
             $length = sizeof($this->getSystemSetting('mobile-api-request-to-survey-parameters'));
             $parameter_names = $this->getSystemSetting('mobile-api-request-to-survey-names');
             $parameter_values = $this->getSystemSetting('mobile-api-request-to-survey-values');

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A REDCap module to route mobile api token requests in the **REDCap Mobile App** 
 - Still in **Control Center > External Modules** configure the module with a URL and optionally, a descriptive text. You may also include parameter name-value pairs to be appended to the URL. Lastly, activate this module for all projects.
 
 
-## How to use
+## How to configure the module
 This module requires a Base URL to be provided as part of the system settings. The following values may be selected to be appended to the URL:
 
     user_firstname
@@ -36,3 +36,6 @@ the rewritten target URL might look like this:
 
 and the text 'About the REDCap Mobile App' will be added on the 'REDCap Mobile App' before the title 'What is the REDCap Mobile App?'.
 
+
+## How to request a mobile token
+To request a token for certain project, go the project and on the left menu under the **Applications** label click the item **REDCap Mobile App**. On the same page, click the button **Request API token**. You will be redirected to the URL provided during the configuration of the module. Once you complete the questionnaire, your token request will be submitted.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A REDCap module to route mobile api token requests in the **REDCap Mobile App** 
 - Still in **Control Center > External Modules** configure the module with a URL and optionally, a descriptive text. You may also include parameter name-value pairs to be appended to the URL. Lastly, activate this module for all projects.
 
 
-## How to configure the module
+## Module Configuration
 This module requires a Base URL to be provided as part of the system settings. The following values may be selected to be appended to the URL:
 
     user_firstname
@@ -37,5 +37,11 @@ the rewritten target URL might look like this:
 and the text 'About the REDCap Mobile App' will be added on the 'REDCap Mobile App' before the title 'What is the REDCap Mobile App?'.
 
 
-## How to request a mobile token
-To request a token for certain project, go the project and on the left menu under the **Applications** label click the item **REDCap Mobile App**. On the same page, click the button **Request API token**. You will be redirected to the URL provided during the configuration of the module. Once you complete the questionnaire, your token request will be submitted.
+## Module Workflow
+1. The user requests a token: On the project in question, the user clicks on the left menu link **REDCap Mobile App** and then on the button **Request API token**. He is redirected to the URL provided during the configuration of the module. Once he completes the questionnaire, the token request will be submitted.
+2. The project manager/administrator receives the request.
+3. The project manager/administrator approves the request.
+4. The project manager/administrator disables the module: The project manager/administrator disables the module in the project by going to the ** External Modules** page (under Applications) and clicking **Disable** next to the **Route Mobile Api Token Requests to Survey** module.
+5. The user goes back to the project in question and clicks the **Request API token** button on the **REDCap Mobile App** page.
+6. The project manager/administrator receives the Mobile App API token request and approves the request.
+Note: you can tell a project has been approved for the Mobile App because the user(s) no longer have to complete the Mobile App Request Survey – because the external module is now disabled in the project, other users can directly request a Mobile App API token via the REDCap Mobile App page in the project.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ and the text 'About the REDCap Mobile App' will be added on the 'REDCap Mobile A
 2. The project manager/administrator receives the request.
 3. The project manager/administrator approves the request.
 4. The project manager/administrator disables the module at the project level: The project manager/administrator disables the module in the _project_ by going to the **External Modules** page (under Applications) and clicking **Disable** next to the **Route Mobile Api Token Requests to Survey** module.
-5. The user goes back to the project in question and clicks the **Request API token** button on the **REDCap Mobile App** page.
-6. The project manager/administrator receives the Mobile App API token request and approves the request.
+5. The project manager/administrator contacts the user: The project manager/administrator sends a message to the user asking him to revisit the mobile API token request page to complete the token request.
+6. The user goes back to the project in question and clicks the **Request API token** button on the **REDCap Mobile App** page.
+7. The project manager/administrator receives the Mobile App API token request and approves the request.
 Note: you can tell a project has been approved for the Mobile App because the user(s) no longer have to complete the Mobile App Request Survey – because the external module is now disabled in the project, other users can directly request a Mobile App API token via the REDCap Mobile App page in the project.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and the text 'About the REDCap Mobile App' will be added on the 'REDCap Mobile A
 1. The user requests a token: On the project in question, the user clicks on the left menu link **REDCap Mobile App** and then on the button **Request API token**. He is redirected to the URL provided during the configuration of the module. Once he completes the questionnaire, the token request will be submitted.
 2. The project manager/administrator receives the request.
 3. The project manager/administrator approves the request.
-4. The project manager/administrator disables the module: The project manager/administrator disables the module in the project by going to the ** External Modules** page (under Applications) and clicking **Disable** next to the **Route Mobile Api Token Requests to Survey** module.
+4. The project manager/administrator disables the module at the project level: The project manager/administrator disables the module in the _project_ by going to the **External Modules** page (under Applications) and clicking **Disable** next to the **Route Mobile Api Token Requests to Survey** module.
 5. The user goes back to the project in question and clicks the **Request API token** button on the **REDCap Mobile App** page.
 6. The project manager/administrator receives the Mobile App API token request and approves the request.
 Note: you can tell a project has been approved for the Mobile App because the user(s) no longer have to complete the Mobile App Request Survey – because the external module is now disabled in the project, other users can directly request a Mobile App API token via the REDCap Mobile App page in the project.


### PR DESCRIPTION
### Overview:
- Targets issue #6.
- Fixes bug:  if the descriptive text was left blank, the word *null* would show up on the token request page.

(Thanks @tlstoffs for making corrections to the workflow section on the `README.md`)
